### PR TITLE
TP-415: Always run `maven-source-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,21 +62,6 @@
 					</executions>
 				</plugin>
 
-				<!-- This plugin makes sure that a source jar is always built together
-					with the binary jar -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>attach-sources</id>
-							<goals>
-								<goal>jar</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
@@ -356,6 +341,21 @@
 				<configuration>
 					<autoVersionSubmodules>true</autoVersionSubmodules>
 				</configuration>
+			</plugin>
+
+			<!-- This plugin makes sure that a source jar is always built together
+				with the binary jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
* Updates pom so that `maven-source-plugin` is always executed when building, instead of (previously) only in the `release` profile with `-Prelease`.