### PR TITLE
TP-349: Allow building on Java11

### DIFF
--- a/mimer-config/pom.xml
+++ b/mimer-config/pom.xml
@@ -13,6 +13,10 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,13 @@
 				<version>${slf4j.version}</version>
 			</dependency>
 
+			<!-- Java 11 back-compatibility -->
+			<dependency>
+				<groupId>javax.annotation</groupId>
+				<artifactId>javax.annotation-api</artifactId>
+				<version>1.3.2</version>
+			</dependency>
+
 			<!-- TEST -->
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
* Adds dependencies so that it is possbile to compile using a java11 jdk.
* The target code is still java8 even if the compiler is java11.

This MR is basically the same changes for `astrix-config` as was done in https://github.com/AvanzaBank/astrix/pull/65