### PR TITLE
Minor Maven fixes

### DIFF
--- a/mimer-config/src/main/java/com/avanza/astrix/config/MapConfigSource.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/MapConfigSource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-	package com.avanza.astrix.config;
+package com.avanza.astrix.config;
 
 import java.util.List;
 import java.util.Map;
@@ -22,15 +22,14 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * Map backed {@link DynamicConfigSource} useful in testing. <p> 
- * 
- * @author Elias Lindholm (elilin)
+ * Map backed {@link DynamicConfigSource} useful in testing. <p>
  *
+ * @author Elias Lindholm (elilin)
  */
 public class MapConfigSource extends AbstractDynamicConfigSource implements MutableConfigSource {
-	
+
 	private final ConcurrentMap<String, ListenableStringProperty> propertyValues = new ConcurrentHashMap<>();
-	
+
 	public MapConfigSource() {
 	}
 
@@ -39,34 +38,34 @@ public class MapConfigSource extends AbstractDynamicConfigSource implements Muta
 		source.forEach((key, value) -> configSource.set(key, value.toString()));
 		return configSource;
 	}
-	
+
 	@Override
 	public String get(String propertyName, DynamicPropertyListener<String> propertyChangeListener) {
 		ListenableStringProperty dynamicProperty = getProperty(propertyName);
 		dynamicProperty.listeners.add(propertyChangeListener);
 		return dynamicProperty.value;
 	}
-	
+
 	public void set(String propertyName, String value) {
 		getProperty(propertyName).set(value);
 	}
-	
+
 	@Override
 	public <T> void set(Setting<T> setting, T value) {
 		String stringRepresentation = value != null ? value.toString() : null;
 		getProperty(setting.name()).set(stringRepresentation);
 	}
-	
+
 	@Override
 	public void set(LongSetting setting, long value) {
 		getProperty(setting.name()).set(Long.toString(value));
 	}
-	
+
 	@Override
 	public void set(BooleanSetting setting, boolean value) {
 		getProperty(setting.name()).set(Boolean.toString(value));
 	}
-	
+
 	private ListenableStringProperty getProperty(String propertyName) {
 		ListenableStringProperty result = propertyValues.get(propertyName);
 		if (result != null) {
@@ -81,17 +80,17 @@ public class MapConfigSource extends AbstractDynamicConfigSource implements Muta
 			set(entry.getKey(), entry.getValue().value);
 		}
 	}
-	
+
 	@Override
 	public String toString() {
 		return this.propertyValues.toString();
 	}
 
 	private static class ListenableStringProperty {
-		
+
 		final List<DynamicPropertyListener<String>> listeners = new CopyOnWriteArrayList<>();
 		volatile String value;
-		
+
 		void propertyChanged(String newValue) {
 			for (DynamicPropertyListener<String> l : listeners) {
 				l.propertyChanged(newValue);
@@ -102,7 +101,7 @@ public class MapConfigSource extends AbstractDynamicConfigSource implements Muta
 			this.value = value;
 			propertyChanged(value);
 		}
-		
+
 		@Override
 		public String toString() {
 			return value;

--- a/mimer-config/src/test/java/com/avanza/astrix/config/MapConfigSourceTest.java
+++ b/mimer-config/src/test/java/com/avanza/astrix/config/MapConfigSourceTest.java
@@ -1,19 +1,37 @@
+/*
+ * Copyright 2020 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.astrix.config;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
-import java.util.Map;
+import java.util.HashMap;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class MapConfigSourceTest {
 
 	@Test
 	public void shouldCreateFromMap() throws Exception {		
-		MapConfigSource source = MapConfigSource.of(Map.of("property1", "value1", "property2", "value2"));
-		assertThat(source.get("property1"), Matchers.equalTo("value1"));
-		assertThat(source.get("property2"), Matchers.equalTo("value2"));
+		MapConfigSource source = MapConfigSource.of(new HashMap<String, Object>() {{
+			put("property1", "value1");
+			put("property2", "value2");
+		}});
+		assertThat(source.get("property1"), equalTo("value1"));
+		assertThat(source.get("property2"), equalTo("value2"));
 	}
 	
 }

--- a/pom.xml
+++ b/pom.xml
@@ -93,38 +93,49 @@
 			</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>JDK9+</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>${java.version}</maven.compiler.release>
+			</properties>
+		</profile>
 	</profiles>
 
 	<properties>
 		<!-- -Xdoclint:NONE ignores validation errors in javadoc -->
 		<additionalparam>-Xdoclint:none</additionalparam>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
+
+		<java.version>8</java.version>
 		<slf4j.version>1.7.25</slf4j.version>
-		<junit.version>4.12</junit.version>
+		<junit.version>4.13.2</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 		<maven-assembly-plugin.version>2.2.1</maven-assembly-plugin.version>
 		<maven-clean-plugin.version>2.5</maven-clean-plugin.version>
-		<maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
 		<maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
 		<maven-install-plugin.version>2.3.1</maven-install-plugin.version>
 		<maven-jar-plugin.version>2.3.1</maven-jar-plugin.version>
 		<maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
-		<maven-plugin-plugin.version>2.7</maven-plugin-plugin.version>
 		<maven-release-plugin.version>2.5.1</maven-release-plugin.version>
 		<maven-resources-plugin.version>2.6</maven-resources-plugin.version>
 		<maven-site-plugin.version>2.2</maven-site-plugin.version>
 		<maven-source-plugin.version>2.1.2</maven-source-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<versions-maven-plugin.version>2.5</versions-maven-plugin.version>
-		<exec-maven-plugin.version>1.2</exec-maven-plugin.version>
 		<maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
 		<license-maven-plugin.version>2.11</license-maven-plugin.version>
 		<maven-scm-plugin.version>1.4</maven-scm-plugin.version>
 		<maven-scm-publish-plugin.version>1.1</maven-scm-publish-plugin.version>
+
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 	</properties>
 
 	<dependencyManagement>
@@ -215,11 +226,6 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-plugin-plugin</artifactId>
-					<version>${maven-plugin-plugin.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
 					<version>${maven-release-plugin.version}</version>
 				</plugin>
@@ -244,19 +250,9 @@
 					<version>${maven-surefire-plugin.version}</version>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>${maven-failsafe-plugin.version}</version>
-				</plugin>
-				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>versions-maven-plugin</artifactId>
 					<version>${versions-maven-plugin.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>exec-maven-plugin</artifactId>
-					<version>${exec-maven-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -295,18 +291,6 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
-			<!-- Set default Java source/target -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<showDeprecation>true</showDeprecation>
-				</configuration>
-			</plugin>
-
 			<!-- Configures jar creation and manifest contents -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -377,19 +361,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-scm-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<includes>
-						<include>**/Test*.java</include>
-						<include>**/*Test.java</include>
-						<include>**/*TestCase.java</include>
-						<include>**/*Tests.java</include>
-					</includes>
-				</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
Enforce JDK level when compiling using a JDK higher than 8.
Add license header to `MapConfigSourceTest`.
Removed some unnecessary stuff from the `pom.xml`
Update JUnit to fix security issue