### PR TITLE
TP-820: Add support for DynamicOptionalProperty<Integer>

### DIFF
--- a/mimer-config/src/main/java/com/avanza/astrix/config/DynamicConfig.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/DynamicConfig.java
@@ -103,6 +103,10 @@ public final class DynamicConfig {
 		return getProperty(name, DynamicBooleanProperty.class, defaultValue, PropertyParser.BOOLEAN_PARSER);
 	}
 
+	public DynamicOptionalProperty<Boolean> getOptionalBooleanProperty(String name) {
+		return new DynamicOptionalProperty<>(getProperty(name, DynamicNullableBooleanProperty.class, null, PropertyParser.BOOLEAN_PARSER));
+	}
+
 	public DynamicLongProperty getLongProperty(String name, long defaultValue) {
 		return getProperty(name, DynamicLongProperty.class, defaultValue, PropertyParser.LONG_PARSER);
 	}
@@ -115,8 +119,8 @@ public final class DynamicConfig {
 		return getProperty(name, DynamicIntProperty.class, defaultValue, PropertyParser.INT_PARSER);
 	}
 
-	public DynamicOptionalProperty<Integer> getOptionalIntProperty(String name) {
-		return new DynamicOptionalProperty<>(getProperty(name, DynamicNullableIntProperty.class, null, PropertyParser.INT_PARSER));
+	public DynamicOptionalProperty<Integer> getOptionalIntegerProperty(String name) {
+		return new DynamicOptionalProperty<>(getProperty(name, DynamicNullableIntegerProperty.class, null, PropertyParser.INT_PARSER));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/mimer-config/src/main/java/com/avanza/astrix/config/DynamicConfig.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/DynamicConfig.java
@@ -107,8 +107,16 @@ public final class DynamicConfig {
 		return getProperty(name, DynamicLongProperty.class, defaultValue, PropertyParser.LONG_PARSER);
 	}
 
+	public DynamicOptionalProperty<Long> getOptionalLongProperty(String name) {
+		return new DynamicOptionalProperty<>(getProperty(name, DynamicNullableLongProperty.class, null, PropertyParser.LONG_PARSER));
+	}
+
 	public DynamicIntProperty getIntProperty(String name, int defaultValue) {
 		return getProperty(name, DynamicIntProperty.class, defaultValue, PropertyParser.INT_PARSER);
+	}
+
+	public DynamicOptionalProperty<Integer> getOptionalIntProperty(String name) {
+		return new DynamicOptionalProperty<>(getProperty(name, DynamicNullableIntProperty.class, null, PropertyParser.INT_PARSER));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableBooleanProperty.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableBooleanProperty.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.config;
+
+final class DynamicNullableBooleanProperty extends AbstractDynamicProperty<Boolean> {
+}

--- a/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableIntProperty.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableIntProperty.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.config;
+
+final class DynamicNullableIntProperty extends AbstractDynamicProperty<Integer> {
+}

--- a/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableIntegerProperty.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableIntegerProperty.java
@@ -15,5 +15,5 @@
  */
 package com.avanza.astrix.config;
 
-final class DynamicNullableIntProperty extends AbstractDynamicProperty<Integer> {
+final class DynamicNullableIntegerProperty extends AbstractDynamicProperty<Integer> {
 }

--- a/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableLongProperty.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/DynamicNullableLongProperty.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.astrix.config;
+
+final class DynamicNullableLongProperty extends AbstractDynamicProperty<Long> {
+}

--- a/mimer-config/src/main/java/com/avanza/astrix/config/DynamicOptionalProperty.java
+++ b/mimer-config/src/main/java/com/avanza/astrix/config/DynamicOptionalProperty.java
@@ -52,4 +52,8 @@ public final class DynamicOptionalProperty<T> implements DynamicProperty<T>, Sup
 		return Optional.ofNullable(getCurrentValue());
 	}
 
+	@Override
+	public String toString() {
+		return delegate.toString();
+	}
 }

--- a/mimer-config/src/test/java/com/avanza/astrix/config/DynamicConfigTest.java
+++ b/mimer-config/src/test/java/com/avanza/astrix/config/DynamicConfigTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 
 class DynamicConfigTest {
 
-
 	private final MapConfigSource firstSource = new MapConfigSource();
 	private final MapConfigSource secondSource = new MapConfigSource();
 	private final DynamicConfig dynamicConfig = new DynamicConfig(Arrays.asList(firstSource, secondSource));
@@ -89,6 +88,42 @@ class DynamicConfigTest {
 
 		firstSource.set("foo", "1");
 		assertEquals(1, intProperty.get());
+	}
+
+	@Test
+	void optionalIntProperty() {
+		DynamicOptionalProperty<Integer> optionalIntProperty = dynamicConfig.getOptionalIntProperty("foo");
+		assertFalse(optionalIntProperty.get().isPresent());
+
+		secondSource.set("foo", "2");
+		assertEquals(2, optionalIntProperty.getCurrentValue());
+
+		firstSource.set("foo", "1");
+		assertEquals(1, optionalIntProperty.getCurrentValue());
+	}
+
+	@Test
+	void longProperty() {
+		DynamicLongProperty longProperty = dynamicConfig.getLongProperty("foo", 0L);
+		assertEquals(0, longProperty.get());
+
+		secondSource.set("foo", Long.toString(Long.MAX_VALUE));
+		assertEquals(Long.MAX_VALUE, longProperty.get());
+
+		firstSource.set("foo", Long.toString(Long.MIN_VALUE));
+		assertEquals(Long.MIN_VALUE, longProperty.get());
+	}
+
+	@Test
+	void optionalLongProperty() {
+		DynamicOptionalProperty<Long> optionalLongProperty = dynamicConfig.getOptionalLongProperty("foo");
+		assertFalse(optionalLongProperty.get().isPresent());
+
+		secondSource.set("foo", Long.toString(Long.MAX_VALUE));
+		assertEquals(Long.MAX_VALUE, optionalLongProperty.getCurrentValue());
+
+		firstSource.set("foo", Long.toString(Long.MIN_VALUE));
+		assertEquals(Long.MIN_VALUE, optionalLongProperty.getCurrentValue());
 	}
 
 	@Test

--- a/mimer-config/src/test/java/com/avanza/astrix/config/DynamicConfigTest.java
+++ b/mimer-config/src/test/java/com/avanza/astrix/config/DynamicConfigTest.java
@@ -79,6 +79,19 @@ class DynamicConfigTest {
 	}
 
 	@Test
+	void optionalBooleanProperty() {
+		DynamicOptionalProperty<Boolean> optionalBooleanProperty = dynamicConfig.getOptionalBooleanProperty("foo");
+		assertFalse(optionalBooleanProperty.get().isPresent());
+
+		secondSource.set("foo", "true");
+		assertTrue(optionalBooleanProperty.get().isPresent());
+		assertTrue(optionalBooleanProperty.getCurrentValue());
+
+		firstSource.set("foo", "false");
+		assertFalse(optionalBooleanProperty.getCurrentValue());
+	}
+
+	@Test
 	void intProperty() {
 		DynamicIntProperty intProperty = dynamicConfig.getIntProperty("foo", 0);
 		assertEquals(0, intProperty.get());
@@ -91,15 +104,16 @@ class DynamicConfigTest {
 	}
 
 	@Test
-	void optionalIntProperty() {
-		DynamicOptionalProperty<Integer> optionalIntProperty = dynamicConfig.getOptionalIntProperty("foo");
-		assertFalse(optionalIntProperty.get().isPresent());
+	void optionalIntegerProperty() {
+		DynamicOptionalProperty<Integer> optionalIntegerProperty = dynamicConfig.getOptionalIntegerProperty("foo");
+		assertFalse(optionalIntegerProperty.get().isPresent());
 
 		secondSource.set("foo", "2");
-		assertEquals(2, optionalIntProperty.getCurrentValue());
+		assertTrue(optionalIntegerProperty.get().isPresent());
+		assertEquals(2, optionalIntegerProperty.getCurrentValue());
 
 		firstSource.set("foo", "1");
-		assertEquals(1, optionalIntProperty.getCurrentValue());
+		assertEquals(1, optionalIntegerProperty.getCurrentValue());
 	}
 
 	@Test
@@ -120,6 +134,7 @@ class DynamicConfigTest {
 		assertFalse(optionalLongProperty.get().isPresent());
 
 		secondSource.set("foo", Long.toString(Long.MAX_VALUE));
+		assertTrue(optionalLongProperty.get().isPresent());
 		assertEquals(Long.MAX_VALUE, optionalLongProperty.getCurrentValue());
 
 		firstSource.set("foo", Long.toString(Long.MIN_VALUE));


### PR DESCRIPTION
* As `DynamicIntProperty` isn't nullable, it cannot be used with `DynamicOptionalProperty`
* Add new, package-local nullable int & long property classes to be used with `DynamicOptionalProperty`